### PR TITLE
fix: echo if no commit needed instead of error in workflow

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -36,5 +36,5 @@ runs:
       shell: bash
       run: |
         git add .vaunt
-        git commit -m "updating Vaunt cards"
+        git commit -m "updating Vaunt cards" || echo "No changes to commit"
         git push origin HEAD


### PR DESCRIPTION
# Description

Updated commit step to just echo "No changes to commit" if there are no changes in the Vaunt cards instead of creating an error in the workflow.
